### PR TITLE
chore: Changes charm name to `manual-tls-certificates`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         with:
           name: tested-charm
-          path: .tox/**/tls-certificates-operator_ubuntu-22.04-amd64.charm
+          path: .tox/**/manual-tls-certificates_ubuntu-22.04-amd64.charm
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
@@ -87,14 +87,14 @@ jobs:
         with:
           name: tested-charm
       - name: Move charm in current directory
-        run: find ./ -name tls-certificates-operator_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
+        run: find ./ -name manual-tls-certificates_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.4.0
         id: channel
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          built-charm-path: "tls-certificates-operator_ubuntu-22.04-amd64.charm"
+          built-charm-path: "manual-tls-certificates_ubuntu-22.04-amd64.charm"
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TLS Certificates Operator
+# Manual TLS Certificates
 
 This charm is used to provide X.509 certificates in environments where certificates are obtained through a manual process.
 
@@ -7,8 +7,8 @@ This charm is used to provide X.509 certificates in environments where certifica
 Deploy the charm and integrate it to a certificate requirer:
 
 ```bash
-juju deploy tls-certificates-operator --channel beta
-juju integrate tls-certificates-operator <TLS Certificates Requirer>
+juju deploy manual-tls-certificates --channel beta
+juju integrate manual-tls-certificates <TLS Certificates Requirer>
 ```
 
 ### Providing X.509 certificates to requesting units
@@ -19,14 +19,13 @@ If the optional parameter relation-id is provided then only the information of t
 The following action will return all certificate requests that don't have certificates already provided, along with further information (relation-id, application_name and unit_name)
 
 ```bash
-juju run tls-certificates-operator/leader get-outstanding-certificate-requests \
-  relation-id=<id>
+juju run manual-tls-certificates/leader get-outstanding-certificate-requests relation-id=<id>
 ```
 
 
 The second action allows the user to provide the certificates and specify the csr.
 ```bash
-juju run tls-certificates-operator/leader provide-certificate \
+juju run manual-tls-certificates/leader provide-certificate \
   relation-id=<id> \
   certificate="$(base64 -w0 certificate.pem)" \
   ca-chain="$(base64 -w0 ca-chain.pem)" \

--- a/actions.yaml
+++ b/actions.yaml
@@ -9,7 +9,7 @@ get-outstanding-certificate-requests:
     relation-id:
       type: integer
       description: >-
-        ID of the relation between the tls-certificate-operator and the requirer.
+        ID of the relation between the manual-tls-certificates and the requirer.
 
 provide-certificate:
   description: >-
@@ -18,7 +18,7 @@ provide-certificate:
     relation-id:
       type: integer
       description: >-
-        ID of the relation between the tls-certificate-operator and the requirer.
+        ID of the relation between the manual-tls-certificates and the requirer.
     certificate-signing-request:
       type: string
       description: >-

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: tls-certificates-operator
+name: manual-tls-certificates
 
-display-name: TLS Certificates Operator
+display-name: Manual TLS Certificates
 docs: https://discourse.charmhub.io/t/tls-certificates-operator-docs-index/11461
 description: |
   Charm responsible for distributing certificates through relationship. Certificates are provided
@@ -11,9 +11,9 @@ description: |
 summary: |
   Charm responsible for distributing certificates through relationship. Certificates are provided
   by the operator through Juju actions.
-website: https://charmhub.io/tls-certificates-operator
-source: https://github.com/canonical/tls-certificates-operator
-issues: https://github.com/canonical/tls-certificates-operator/issues
+website: https://charmhub.io/manual-tls-certificates
+source: https://github.com/canonical/manual-tls-certificates-operator
+issues: https://github.com/canonical/manual-tls-certificates-operator/issues
 
 provides:
   certificates:

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 CERTIFICATES_RELATION = "certificates"
 
 
-class TLSCertificatesOperatorCharm(CharmBase):
+class ManualTLSCertificatesCharm(CharmBase):
     """Main class to handle Juju events."""
 
     def __init__(self, *args):
@@ -250,4 +250,4 @@ class TLSCertificatesOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(TLSCertificatesOperatorCharm)
+    main(ManualTLSCertificatesCharm)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,11 +16,11 @@ from juju.errors import JujuError
 
 logger = logging.getLogger(__name__)
 
-APPLICATION_NAME = "tls-certificates-operator"
+APPLICATION_NAME = "manual-tls-certificates"
 TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
 
 
-class TestTLSCertificatesOperator:
+class TestManualTLSCertificates:
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
     async def charm(self, ops_test):
@@ -215,7 +215,7 @@ async def run_get_certificate_action(ops_test) -> dict:
 
 
 async def run_get_outstanding_csrs_action(ops_test) -> dict:
-    """Runs `get-outstanding-certificate-requests` on the `tls-certificates-operator/0` unit.
+    """Runs `get-outstanding-certificate-requests` on the `manual-tls-certificates/0` unit.
 
     Args:
         ops_test (OpsTest): OpsTest
@@ -223,8 +223,8 @@ async def run_get_outstanding_csrs_action(ops_test) -> dict:
     Returns:
         dict: Action output
     """
-    tls_operator_unit = ops_test.model.units[f"{APPLICATION_NAME}/0"]
-    action = await tls_operator_unit.run_action(
+    manual_tls_unit = ops_test.model.units[f"{APPLICATION_NAME}/0"]
+    action = await manual_tls_unit.run_action(
         action_name="get-outstanding-certificate-requests",
     )
     action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
@@ -239,7 +239,7 @@ async def run_provide_certificate_action(
     ca_chain: str,
     csr: str,
 ) -> dict:
-    """Runs `provide-certificate` on the `tls-certificates-operator/0` unit.
+    """Runs `provide-certificate` on the `manual-tls-certificates/0` unit.
 
     Args:
         ops_test (OpsTest): OpsTest
@@ -252,8 +252,8 @@ async def run_provide_certificate_action(
     Returns:
         dict: Action output
     """
-    tls_operator_unit = ops_test.model.units[f"{APPLICATION_NAME}/0"]
-    action = await tls_operator_unit.run_action(
+    manual_tls_unit = ops_test.model.units[f"{APPLICATION_NAME}/0"]
+    action = await manual_tls_unit.run_action(
         action_name="provide-certificate",
         **{
             "relation-id": relation_id,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from ops import testing
 from ops.model import ActiveStatus
 
-from charm import TLSCertificatesOperatorCharm
+from charm import ManualTLSCertificatesCharm
 
 TLS_CERTIFICATES_PROVIDES_PATH = (
     "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesProvidesV2"
@@ -38,7 +38,7 @@ class TestCharm(unittest.TestCase):
         return certificate
 
     def setUp(self):
-        self.harness = testing.Harness(TLSCertificatesOperatorCharm)
+        self.harness = testing.Harness(ManualTLSCertificatesCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()


### PR DESCRIPTION
# Description

Changes charm name to `manual-tls-certificates`. Please wait for the charm name to be updated in charmhub before merging this here. Ref: https://discourse.charmhub.io/t/change-charm-name-in-charmhub/12174

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
