### PR TITLE
feat: Remove scaling restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following action will return all certificate requests that don't have certif
 NOTE: If you happen to scale `manual-tls-certificates`, you must run actions on the leader unit. However, there is currently no benefit to scaling this charm.
 
 ```bash
-juju run manual-tls-certificates/leader get-outstanding-certificate-requests relation-id=${relation_id}
+juju run manual-tls-certificates/leader get-outstanding-certificate-requests relation-id=<id>
 ```
 
 The second action allows the user to provide the certificates and specify the csr.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ If the optional parameter relation-id is provided then only the information of t
 
 The following action will return all certificate requests that don't have certificates already provided, along with further information (relation-id, application_name and unit_name)
 
+NOTE: If you happen to scale `manual-tls-certificates`, you must run actions on the leader unit. However, there is currently no benefit to scaling this charm.
+
 ```bash
-juju run manual-tls-certificates/leader get-outstanding-certificate-requests relation-id=<id>
+juju run manual-tls-certificates/leader get-outstanding-certificate-requests relation-id=${relation_id}
 ```
 
-
 The second action allows the user to provide the certificates and specify the csr.
+
 ```bash
 juju run manual-tls-certificates/leader provide-certificate \
   relation-id=<id> \

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,8 +38,6 @@ class ManualTLSCertificatesCharm(CharmBase):
     def __init__(self, *args):
         """Observes config change and certificate request events."""
         super().__init__(*args)
-        if not self.unit.is_leader():
-            raise NotImplementedError("Scaling is not implemented for this charm")
         self.tls_certificates = TLSCertificatesProvidesV2(self, CERTIFICATES_RELATION)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(


### PR DESCRIPTION
# Description

This change removes the scaling restriction on the `manual-tls-certificates` charm.

This charm is workloadless, and can operate fine with scaling. That being said, the `tls-certificates-interface` that it depends on seems to hardcode some restrictions to the leader unit. This means that all actions need to be performed on the leader unit.

I'm honestly not sure what the best approach is. This was the quickest, but we could also update the `tls-certificates-interface` to support non-leader units.

I fear that there may be some edge cases around when the charm is scaled relative to other operations.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
