### PR TITLE
fix: Remove chain validation from integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -212,15 +212,6 @@ class TestManualTLSCertificatesOperator:
         assert get_certificate_action_output["ca-certificate"] == ca_certificate_pem.decode(
             "utf-8"
         ).strip("\n")
-        formatted_chain = (
-            get_certificate_action_output["chain"]
-            .replace("[", "")
-            .replace("]", "")
-            .replace("'", "")
-            .replace(", ", "\n")
-            .replace("\\n", "\n")
-        )
-        assert formatted_chain == ca_chain_pem.decode("utf-8").strip("\n")
 
 
 async def run_get_certificate_action(ops_test, unit_name: str) -> dict:


### PR DESCRIPTION
# Description

The tls-certificates requirer doesn't store ca chains anymore and won't return them in the `get-certificate` juju action (reference below). Here when we run the `get-certificate` action, we don't look at the ca chain anymore. This fixes an issue currently in main that prevents integration tests from running correctly.

## Reference
- https://github.com/canonical/tls-certificates-requirer-operator/pull/39

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
