### PR TITLE
feat: make ca-chain an optional parameter

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -39,5 +39,4 @@ provide-certificate:
     - relation-id
     - certificate-signing-request
     - certificate
-    - ca-chain
     - ca-certificate

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,17 +105,19 @@ class ManualTLSCertificatesCharm(CharmBase):
         if not self._relation_created("certificates"):
             event.fail(message="No certificates relation has been created yet.")
             return
-
+        ca_chain = event.params.get("ca-chain", None)
+        if not ca_chain:
+            ca_chain = event.params["ca-certificate"]
         if not self._action_certificates_are_valid(
             certificate=event.params["certificate"],
             ca_certificate=event.params["ca-certificate"],
             certificate_signing_request=event.params["certificate-signing-request"],
-            ca_chain=event.params["ca-chain"],
+            ca_chain=ca_chain,
         ):
             event.fail(message="Action input is not valid.")
             return
 
-        ca_chain_list = parse_ca_chain(base64.b64decode(event.params["ca-chain"]).decode())
+        ca_chain_list = parse_ca_chain(base64.b64decode(ca_chain).decode())
         csr = base64.b64decode(event.params["certificate-signing-request"]).decode("utf-8").strip()
         certificate = base64.b64decode(event.params["certificate"]).decode("utf-8").strip()
         ca_cert = base64.b64decode(event.params["ca-certificate"]).decode("utf-8").strip()

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -84,7 +84,7 @@ def ca_chain_is_valid(ca_chain: List[str]) -> bool:
     Returns:
         whether the ca chain is valid.
     """
-    if len(ca_chain) < 2:
+    if len(ca_chain) < 1:
         logger.warning("Invalid CA chain: It must contain at least 2 certificates.")
         return False
     for ca_cert, cert in zip(ca_chain, ca_chain[1:]):

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -85,7 +85,7 @@ def ca_chain_is_valid(ca_chain: List[str]) -> bool:
         whether the ca chain is valid.
     """
     if len(ca_chain) < 1:
-        logger.warning("Invalid CA chain: It must contain at least 2 certificates.")
+        logger.warning("Invalid CA chain: It must contain at least 1 certificates.")
         return False
     for ca_cert, cert in zip(ca_chain, ca_chain[1:]):
         try:

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -74,10 +74,8 @@ class TestHelpers(unittest.TestCase):
         ca_chain_list: List[str] = []
         self.assertFalse(ca_chain_is_valid(ca_chain_list))
 
-    def test_given_one_certificate_in_ca_chain_when_ca_chain_is_valid_returns_false(self):
-        ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
-        ca_chain_list = parse_ca_chain(ca_chain)[:-1]
-        self.assertFalse(ca_chain_is_valid(ca_chain_list))
+    def test_given_zero_certificate_in_ca_chain_when_ca_chain_is_valid_returns_false(self):
+        self.assertFalse(ca_chain_is_valid([]))
 
     def test_given_invalid_issuer_ca_chain_when_ca_chain_is_valid_returns_false(self):
         ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")


### PR DESCRIPTION
# Description

Make ca-chain an optional parameter. 

Fixes #157 

## Rationale

It doesn't make much sense for `ca-chain` to be a required parameter. Especially in contexts of self-signed certificates. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
