### PR TITLE
fix: provide-certificates when relation id is not provided

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,10 @@ class ManualTLSCertificatesCharm(CharmBase):
         """
         self.unit.status = ActiveStatus("Ready to provide certificates.")
 
-    def _on_get_outstanding_certificate_requests_action(self, event: ActionEvent) -> None:
+    def _on_get_outstanding_certificate_requests_action(
+        self,
+        event: ActionEvent,
+    ) -> None:
         """Return outstanding certificate requests.
 
         Args:
@@ -119,9 +122,17 @@ class ManualTLSCertificatesCharm(CharmBase):
             return
 
         ca_chain_list = parse_ca_chain(base64.b64decode(ca_chain).decode())
-        csr = base64.b64decode(event.params["certificate-signing-request"]).decode("utf-8").strip()
-        certificate = base64.b64decode(event.params["certificate"]).decode("utf-8").strip()
-        ca_cert = base64.b64decode(event.params["ca-certificate"]).decode("utf-8").strip()
+        csr = (
+            base64.b64decode(event.params["certificate-signing-request"])
+            .decode("utf-8")
+            .strip()
+        )
+        certificate = (
+            base64.b64decode(event.params["certificate"]).decode("utf-8").strip()
+        )
+        ca_cert = (
+            base64.b64decode(event.params["ca-certificate"]).decode("utf-8").strip()
+        )
 
         if not csr_matches_certificate(csr=csr, cert=certificate):
             event.fail(message="Certificate and CSR do not match.")
@@ -133,7 +144,9 @@ class ManualTLSCertificatesCharm(CharmBase):
                 relation_ids_with_given_csr.append(relation.id)
 
         given_relation_id = event.params.get("relation-id", None)
-        err = self._relation_id_parameter_valid(relation_ids_with_given_csr, given_relation_id)
+        err = self._relation_id_parameter_valid(
+            relation_ids_with_given_csr, given_relation_id
+        )
         if err:
             event.fail(message=err)
             return
@@ -145,7 +158,9 @@ class ManualTLSCertificatesCharm(CharmBase):
                 ca=ca_cert,
                 chain=ca_chain_list,
                 relation_id=(
-                    given_relation_id if given_relation_id else relation_ids_with_given_csr[0]
+                    given_relation_id
+                    if given_relation_id
+                    else relation_ids_with_given_csr[0]
                 ),
             )
         except RuntimeError:
@@ -191,7 +206,7 @@ class ManualTLSCertificatesCharm(CharmBase):
         if not relation_id and len(requirer_relation_ids) > 1:
             return "Multiple requirers with the same CSR found."
 
-        if relation_id not in requirer_relation_ids:
+        if relation_id is not None and relation_id not in requirer_relation_ids:
             return "Requested relation id is not the correct id of any found CSR's."
         return ""
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -266,7 +266,9 @@ async def _wait_for_certificate_request(ops_test: OpsTest):
     timeout = 60 * 5
     while time.time() < start_time + timeout:
         action_output = await run_get_outstanding_csrs_action(ops_test)
-        if json.loads(action_output["result"]):
+        action_output_result = json.loads(action_output["result"])
+        csr = action_output_result[0].get("csr", None)
+        if csr:
             return
         time.sleep(5)
     raise TimeoutError("Timeout waiting for certificate request.")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -114,7 +114,9 @@ class TestManualTLSCertificatesOperator:
             series="jammy",
         )
 
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME], status="active", timeout=1000
+        )
 
     async def test_given_requirer_requests_certificate_creation_when_deploy_then_status_is_active(  # noqa: E501
         self, ops_test: OpsTest, charm, cleanup
@@ -170,7 +172,9 @@ class TestManualTLSCertificatesOperator:
             wait_for_at_least_units=3,
         )
 
-        get_outstanding_csrs_action_output = await run_get_outstanding_csrs_action(ops_test)
+        get_outstanding_csrs_action_output = await run_get_outstanding_csrs_action(
+            ops_test
+        )
 
         get_outstanding_csrs_action_output = json.loads(
             get_outstanding_csrs_action_output["result"]
@@ -209,9 +213,9 @@ class TestManualTLSCertificatesOperator:
         assert get_certificate_action_output["certificate"] == certificate_pem.decode(
             "utf-8"
         ).strip("\n")
-        assert get_certificate_action_output["ca-certificate"] == ca_certificate_pem.decode(
-            "utf-8"
-        ).strip("\n")
+        assert get_certificate_action_output[
+            "ca-certificate"
+        ] == ca_certificate_pem.decode("utf-8").strip("\n")
 
 
 async def run_get_certificate_action(ops_test, unit_name: str) -> dict:
@@ -227,7 +231,9 @@ async def run_get_certificate_action(ops_test, unit_name: str) -> dict:
     """
     tls_requirer_unit = ops_test.model.units[unit_name]
     action = await tls_requirer_unit.run_action(action_name="get-certificate")
-    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
+    action_output = await ops_test.model.get_action_output(
+        action_uuid=action.entity_id, wait=240
+    )
     return action_output
 
 
@@ -245,13 +251,14 @@ async def run_get_outstanding_csrs_action(ops_test: OpsTest) -> dict:
     action = await manual_tls_unit.run_action(
         action_name="get-outstanding-certificate-requests",
     )
-    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
+    action_output = await ops_test.model.get_action_output(
+        action_uuid=action.entity_id, wait=240
+    )
     return action_output
 
 
 async def run_provide_certificate_action(
     ops_test,
-    relation_id: int,
     certificate: str,
     ca_certificate: str,
     ca_chain: str,
@@ -274,12 +281,13 @@ async def run_provide_certificate_action(
     action = await manual_tls_unit.run_action(
         action_name="provide-certificate",
         **{
-            "relation-id": relation_id,
             "certificate": certificate,
             "ca-certificate": ca_certificate,
             "ca-chain": ca_chain,
             "certificate-signing-request": csr,
         },
     )
-    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
+    action_output = await ops_test.model.get_action_output(
+        action_uuid=action.entity_id, wait=240
+    )
     return action_output

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -49,14 +49,18 @@ class TestCharm(unittest.TestCase):
         csr_bytes = TestCharm._encode_in_base64(csr)
         certificate = self.get_certificate_from_file(filename="tests/certificate.pem")
         certificate_bytes = TestCharm._encode_in_base64(certificate)
-        ca_certificate = self.get_certificate_from_file(filename="tests/ca_certificate.pem")
+        ca_certificate = self.get_certificate_from_file(
+            filename="tests/ca_certificate.pem"
+        )
         ca_certificate_bytes = TestCharm._encode_in_base64(ca_certificate)
         ca_chain = self.get_certificate_from_file(filename="tests/ca_chain.pem")
         ca_chain_bytes = TestCharm._encode_in_base64(ca_chain)
 
         self.decoded_csr = TestCharm._decode_from_base64(csr_bytes)
         self.decoded_certificate = TestCharm._decode_from_base64(certificate_bytes)
-        self.decoded_ca_certificate = TestCharm._decode_from_base64(ca_certificate_bytes)
+        self.decoded_ca_certificate = TestCharm._decode_from_base64(
+            ca_certificate_bytes
+        )
         self.decoded_ca_chain = TestCharm._decode_from_base64(ca_chain_bytes)
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_outstanding_certificate_requests")
@@ -74,7 +78,9 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.charm._set_active_status(Mock())
         self.assertEqual(
-            ActiveStatus("1 outstanding requests, use juju actions to provide certificates"),
+            ActiveStatus(
+                "1 outstanding requests, use juju actions to provide certificates"
+            ),
             self.harness.charm.unit.status,
         )
 
@@ -84,7 +90,9 @@ class TestCharm(unittest.TestCase):
     ):
         patch_get_requirer_units_csrs_with_no_certs.return_value = []
         self.harness.charm._set_active_status(Mock())
-        self.assertEqual(ActiveStatus("No outstanding requests."), self.harness.charm.unit.status)
+        self.assertEqual(
+            ActiveStatus("No outstanding requests."), self.harness.charm.unit.status
+        )
 
     def test_given_no_requirer_application_when_get_outstanding_certificate_requests_action_then_event_fails(  # noqa: E501
         self,
@@ -111,7 +119,9 @@ class TestCharm(unittest.TestCase):
         patch_get_requirer_units_csrs_with_no_certs.return_value = example_unit_csrs
         event = Mock()
         self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
-        event.set_results.assert_called_once_with({"result": json.dumps([vars(requirer_csr)])})
+        event.set_results.assert_called_once_with(
+            {"result": json.dumps([vars(requirer_csr)])}
+        )
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_outstanding_certificate_requests")
     def test_given_requirer_and_no_outstanding_certs_when_get_outstanding_certificate_requests_action_then_empty_list_is_returned(  # noqa: E501
@@ -132,7 +142,9 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_outstanding_certificate_requests_action(event=event)
         event.set_results.assert_called_once_with({"result": "[]"})
 
-    def test_given_relation_not_created_when_provide_certificate_action_then_event_fails(self):
+    def test_given_relation_not_created_when_provide_certificate_action_then_event_fails(
+        self,
+    ):
         csr = self.get_certificate_from_file(filename="tests/csr.pem")
         csr = TestCharm._encode_in_base64(csr)
 
@@ -192,7 +204,9 @@ class TestCharm(unittest.TestCase):
             "relation-id": relation_id,
         }
         self.harness.charm._on_provide_certificate_action(event=event)
-        event.fail.assert_called_once_with(message="CSR was not found in any requirer databags.")
+        event.fail.assert_called_once_with(
+            message="CSR was not found in any requirer databags."
+        )
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     def test_given_no_relation_id_provided_csr_does_not_exist_in_requirer_when_provide_certificate_action_then_event_fails(  # noqa: E501
@@ -220,15 +234,21 @@ class TestCharm(unittest.TestCase):
             "ca-chain": self.decoded_ca_chain,
         }
         self.harness.charm._on_provide_certificate_action(event=event)
-        event.fail.assert_called_once_with(message="CSR was not found in any requirer databags.")
+        event.fail.assert_called_once_with(
+            message="CSR was not found in any requirer databags."
+        )
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     def test_given_no_relation_id_provided_csr_exists_in_2_requirers_when_provide_certificate_action_then_event_fails(  # noqa: E501
         self, patch_get_requirer_csrs
     ):
         requirer_app_name = "requirer"
-        relation_id_1 = self.harness.add_relation("certificates", f"{requirer_app_name}-1")
-        relation_id_2 = self.harness.add_relation("certificates", f"{requirer_app_name}-2")
+        relation_id_1 = self.harness.add_relation(
+            "certificates", f"{requirer_app_name}-1"
+        )
+        relation_id_2 = self.harness.add_relation(
+            "certificates", f"{requirer_app_name}-2"
+        )
 
         csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
         example_unit_csrs = [
@@ -261,15 +281,21 @@ class TestCharm(unittest.TestCase):
             "ca-chain": self.decoded_ca_chain,
         }
         self.harness.charm._on_provide_certificate_action(event=event)
-        event.fail.assert_called_once_with(message="Multiple requirers with the same CSR found.")
+        event.fail.assert_called_once_with(
+            message="Multiple requirers with the same CSR found."
+        )
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     def test_given_relation_id_doesnt_match_found_csr_relation_id_when_provide_certificate_action_then_event_fails(  # noqa: E501
         self, patch_get_requirer_csrs
     ):
         requirer_app_name = "requirer"
-        relation_id_1 = self.harness.add_relation("certificates", f"{requirer_app_name}-1")
-        relation_id_2 = self.harness.add_relation("certificates", f"{requirer_app_name}-2")
+        relation_id_1 = self.harness.add_relation(
+            "certificates", f"{requirer_app_name}-1"
+        )
+        relation_id_2 = self.harness.add_relation(
+            "certificates", f"{requirer_app_name}-2"
+        )
 
         csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
         example_unit_csrs = [
@@ -393,6 +419,39 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
     @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
+    def test_given_valid_input_without_relation_id_when_provide_certificate_action_then_certificate_is_provided(
+        self, patch_set_relation_cert, patch_get_requirer_csrs
+    ):
+        requirer_app_name = "requirer"
+        relation_id = self.harness.add_relation("certificates", requirer_app_name)
+        csr_from_file = self.get_certificate_from_file(filename="tests/csr.pem")
+        example_unit_csrs = [
+            RequirerCSR(
+                relation_id=relation_id,
+                application_name=requirer_app_name,
+                unit_name=f"{requirer_app_name}/0",
+                csr=csr_from_file,
+                is_ca=False,
+            )
+        ]
+        patch_get_requirer_csrs.return_value = example_unit_csrs
+
+        event = Mock()
+        event.params = {
+            "certificate-signing-request": self.decoded_csr,
+            "certificate": self.decoded_certificate,
+            "ca-certificate": self.decoded_ca_certificate,
+            "ca-chain": self.decoded_ca_chain,
+        }
+
+        self.harness.charm._on_provide_certificate_action(event=event)
+        event.set_results.assert_called_once_with(
+            {"result": "Certificates successfully provided."}
+        )
+        patch_set_relation_cert.assert_called_once()
+
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.get_requirer_csrs")
+    @patch(f"{TLS_CERTIFICATES_PROVIDES_PATH}.set_relation_certificate")
     def test_given_runtime_error_during_set_relation_certificate_when_provide_certificate_action_then_event_fails(  # noqa: E501
         self, patch_set_relation_cert, patch_get_requirer_csrs
     ):
@@ -421,4 +480,6 @@ class TestCharm(unittest.TestCase):
         }
 
         self.harness.charm._on_provide_certificate_action(event=event)
-        event.fail.assert_called_once_with(message="Relation does not exist with the provided id.")
+        event.fail.assert_called_once_with(
+            message="Relation does not exist with the provided id."
+        )


### PR DESCRIPTION
# Description

Address an issue where the charm would return an error message when the user didn't provide the relation id in the `provide-certificate` juju action.

Fixes #177 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
