### PR TITLE
fix: freeze lxd to 5.20/stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
           juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.29-strict/stable
+          lxd-channel: 5.20/stable
       - name: Run integration tests
         run: tox -e integration
       - name: Archive Tested Charm


### PR DESCRIPTION
# Description

Charmcraft currently does not work with the latest lxd version (5.21/stable). This prevents other PR's being merged as CI is failing. This change freezes lxd to 5.20/stable. 

## Reference
- https://github.com/canonical/charmcraft/issues/1640

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
