### PR TITLE
chore: centralise status management using collect status

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,7 +76,9 @@ class TestCharm(unittest.TestCase):
                 is_ca=False,
             )
         ]
-        self.harness.charm._set_active_status(Mock())
+
+        self.harness.evaluate_status()
+
         self.assertEqual(
             ActiveStatus(
                 "1 outstanding requests, use juju actions to provide certificates"
@@ -89,7 +91,9 @@ class TestCharm(unittest.TestCase):
         self, patch_get_requirer_units_csrs_with_no_certs
     ):
         patch_get_requirer_units_csrs_with_no_certs.return_value = []
-        self.harness.charm._set_active_status(Mock())
+
+        self.harness.evaluate_status()
+
         self.assertEqual(
             ActiveStatus("No outstanding requests."), self.harness.charm.unit.status
         )


### PR DESCRIPTION
# Description

Here we centralize and simplify charm status management using the `collect-status` event handler.

## Rationale

The intent is to standardise and simplify status management accross all TLS owned charms. 

## Reference
- https://ops.readthedocs.io/en/latest/#ops.CharmEvents.collect_unit_status

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
