### PR TITLE
style: Format using ruff

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       parser: The pytest command line parser.
     """
     parser.addoption(
-        "--charm_path",
-        action="store",
-        default=None,
-        help="Path to the charm under test"
+        "--charm_path", action="store", default=None, help="Path to the charm under test"
     )
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -114,9 +114,7 @@ class TestManualTLSCertificatesOperator:
             series="jammy",
         )
 
-        await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME], status="active", timeout=1000
-        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
 
     async def test_given_requirer_requests_certificate_creation_when_deploy_then_status_is_active(  # noqa: E501
         self, ops_test: OpsTest, charm, cleanup
@@ -174,9 +172,7 @@ class TestManualTLSCertificatesOperator:
 
         await _wait_for_certificate_request(ops_test)
 
-        get_outstanding_csrs_action_output = await run_get_outstanding_csrs_action(
-            ops_test
-        )
+        get_outstanding_csrs_action_output = await run_get_outstanding_csrs_action(ops_test)
 
         get_outstanding_csrs_action_output = json.loads(
             get_outstanding_csrs_action_output["result"]
@@ -214,9 +210,9 @@ class TestManualTLSCertificatesOperator:
         assert get_certificate_action_output["certificate"] == certificate_pem.decode(
             "utf-8"
         ).strip("\n")
-        assert get_certificate_action_output[
-            "ca-certificate"
-        ] == ca_certificate_pem.decode("utf-8").strip("\n")
+        assert get_certificate_action_output["ca-certificate"] == ca_certificate_pem.decode(
+            "utf-8"
+        ).strip("\n")
 
 
 async def run_get_certificate_action(ops_test, unit_name: str) -> dict:
@@ -232,9 +228,7 @@ async def run_get_certificate_action(ops_test, unit_name: str) -> dict:
     """
     tls_requirer_unit = ops_test.model.units[unit_name]
     action = await tls_requirer_unit.run_action(action_name="get-certificate")
-    action_output = await ops_test.model.get_action_output(
-        action_uuid=action.entity_id, wait=240
-    )
+    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
     return action_output
 
 
@@ -252,9 +246,7 @@ async def run_get_outstanding_csrs_action(ops_test: OpsTest) -> dict:
     action = await manual_tls_unit.run_action(
         action_name="get-outstanding-certificate-requests",
     )
-    action_output = await ops_test.model.get_action_output(
-        action_uuid=action.entity_id, wait=240
-    )
+    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
     return action_output
 
 
@@ -303,7 +295,5 @@ async def run_provide_certificate_action(
             "certificate-signing-request": csr,
         },
     )
-    action_output = await ops_test.model.get_action_output(
-        action_uuid=action.entity_id, wait=240
-    )
+    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
     return action_output

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
