### PR TITLE
build: re-compile pip dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,36 +6,36 @@
 #
 asttokens==2.4.1
     # via stack-data
-backports-strenum==1.3.1
-    # via juju
 bcrypt==4.2.0
     # via paramiko
 cachetools==5.4.0
     # via google-auth
 certifi==2024.7.4
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.3.0
     # via -r test-requirements.in
 coverage[toml]==7.6.9
     # via -r test-requirements.in
 cryptography==44.0.0
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-exceptiongroup==1.2.2
-    # via
-    #   ipython
-    #   pytest
 executing==2.0.1
     # via stack-data
 google-auth==2.33.0
@@ -43,7 +43,9 @@ google-auth==2.33.0
 hvac==2.3.0
     # via juju
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
@@ -75,7 +77,9 @@ oauthlib==3.2.2
     #   kubernetes
     #   requests-oauthlib
 ops==2.17.1
-    # via ops-scenario
+    # via
+    #   -c requirements.txt
+    #   ops-scenario
 ops-scenario==7.0.5
     # via -r test-requirements.in
 packaging==24.1
@@ -93,7 +97,9 @@ pluggy==1.5.0
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==4.25.3
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -106,7 +112,9 @@ pyasn1==0.6.0
 pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -139,6 +147,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   ops
@@ -146,6 +155,7 @@ pyyaml==6.0.1
     #   pytest-operator
 requests==2.32.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
@@ -165,11 +175,6 @@ six==1.16.0
     #   python-dateutil
 stack-data==0.6.3
     # via ipython
-tomli==2.2.1
-    # via
-    #   coverage
-    #   ipdb
-    #   pytest
 toposort==1.10
     # via juju
 traitlets==5.14.3
@@ -178,7 +183,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
-    #   ipython
+    #   -c requirements.txt
     #   juju
     #   pyright
     #   typing-inspect
@@ -186,12 +191,14 @@ typing-inspect==0.9.0
     # via juju
 urllib3==2.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   ops
 websockets==14.1


### PR DESCRIPTION
I'm not sure what happened here, but `backports-strenum==1.3.1`  doesn't work on Python 3.11 or above, so this shouldn't have been included here.

This was likely an issue upstream that has been addressed.

All I did was re-run the pip-compile command with the same python version