### PR TITLE
fix: Use multiarch publish workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,14 +14,14 @@ concurrency:
 
 jobs:
   lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@v0
 
   static-analysis:
     name: Static analysis
-    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@v0
 
   unit-tests-with-coverage:
-    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@v0
 
   build:
     needs:
@@ -43,6 +43,6 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v0
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,6 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@main
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,5 +44,7 @@ jobs:
       - integration-test
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v0
+    with:
+      track-name: latest
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}


### PR DESCRIPTION
# Description

The work for publishing the charm was changed to the shared workflow for a single architecture, but this charm is built for both `amd64` and `arm64`. The publish job was not working because it could not find the right artifact.

This switches to the multiarch workflow to get the right artifact per architecture.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
