### PR TITLE
chore: add optional field to requires type relations

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,7 @@ requires:
   tracing:
     interface: tracing
     limit: 1
+    optional: true
 
 provides:
   certificates:


### PR DESCRIPTION
# Description

We add the `optional` field next to each integration the charm requires. This fields defines if the relation is required for the charm to function. For the time being this field is informational only, i.e. Juju won't do anything with it. However, the SQA team uses this field to perform charm integration tests.

I am going through all of our charms and specifying which relation is optional and which one isn't. 

## Reference
- https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#peers-provides-and-requires

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
