### PR TITLE
fix: Use latest/stable when installing charmcraft in the promote workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -45,6 +45,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: 1/${{ env.promote-to }}
           origin-channel: 1/${{ env.promote-from }}
-          charmcraft-channel: 1/stable
+          charmcraft-channel: latest/stable
           base-channel: "24.04"
           base-architecture: ${{ github.event.inputs.arch }}


### PR DESCRIPTION
# Description

```
error: snap "charmcraft" is not available on 1/stable but is available to
       install on the following tracks:
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
