### PR TITLE
fix: use ca-certificate as ca-chain if not provided

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -169,13 +169,8 @@ class ManualTLSCertificatesCharm(CharmBase):
         if not self._relation_created("certificates"):
             event.fail(message="No certificates relation has been created yet.")
             return
+
         try:
-            ca_chain = [
-                Certificate.from_string(
-                    cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-                )
-                for cert in parse_ca_chain(decode_action_base64_input(event.params["ca-chain"]))
-            ]
             certificate = Certificate.from_string(
                 decode_action_base64_input(event.params["certificate"])
             )
@@ -185,6 +180,17 @@ class ManualTLSCertificatesCharm(CharmBase):
             csr = CertificateSigningRequest.from_string(
                 decode_action_base64_input(event.params["certificate-signing-request"])
             )
+            if event.params.get("ca-chain"):
+                ca_chain = [
+                    Certificate.from_string(
+                        cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+                    )
+                    for cert in parse_ca_chain(
+                        decode_action_base64_input(event.params["ca-chain"])
+                    )
+                ]
+            else:
+                ca_chain = [certificate, ca_certificate]
         except KeyError:
             event.fail(message="One or more action parameters are missing.")
             return


### PR DESCRIPTION
Action provide-certificate fails with KeyError when ca-chain option is not provided.

If user does not provide ca-chain as action params, use [certificate, ca-certificate] as ca-chain.

Fixes: https://github.com/canonical/manual-tls-certificates-operator/issues/157

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
