### PR TITLE
feat: update tf module to be cc008 compliant

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -2,8 +2,7 @@
 **/.terraform/*
 
 # .tfstate files
-*.tfstate
-*.tfstate.*
+*.tfstate*
 
 # Crash log files
 crash.log
@@ -23,6 +22,6 @@ override.tf.json
 .terraformrc
 terraform.rc
 
-# Lock file (optional - remove this line if you want to commit the lock file)
+# Lock file
 .terraform.lock.hcl
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -8,45 +8,60 @@ for the Juju Terraform provider.
 
 ## Requirements
 
-This module requires a Juju model to be available. Refer to the [usage](#usage)
-section for more details.
+- Terraform >= 1.0
+- Juju Terraform provider >= 1.0.0, < 2.0.0
+- An existing Juju model
 
 ## API
 
 ### Inputs
 
-This module offers the following configurable inputs:
-
-| Name          | Type         | Description                                               | Default                    | Required |
-|:--------------|:-------------|:----------------------------------------------------------|:---------------------------|:--------:|
-| `app_name`    | string       | Application name                                          | manual-tls-certificates    |          |
-| `base`        | string       | Base version to use for deployed machine                  | ubuntu@22.04               |          |
-| `channel`     | string       | Channel that charm is deployed from                       | latest/stable              |          |
-| `config`      | map(string)  | Map of charm configuration options to pass at deployment  | {}                         |          |
-| `constraints` | string       | Constraints for the charm deployment                      | ""                         |          |
-| `model_uuid`  | string       | UUID of the Juju model to deploy to                       |                            |    Y     |
-| `revision`    | number       | Revision number of charm to deploy                        | null                       |          |
-| `units`       | number       | Number of units to deploy                                 | 1                          |          |
+| Name          | Type        | Description                                                        | Default                     | Required |
+|---------------|-------------|--------------------------------------------------------------------|-----------------------------|:--------:|
+| `app_name`    | string      | Name of the application                                            | `"manual-tls-certificates"` |          |
+| `base`        | string      | Operating system (e.g. ubuntu@22.04)                               | `null`                      |          |
+| `channel`     | string      | Charm channel to deploy from                                       | `"1/stable"`                |          |
+| `config`      | map(string) | Map of charm configuration options                                 | `{}`                        |          |
+| `constraints` | string      | Constraints string                                                 | `null`                      |          |
+| `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                             |    Y     |
+| `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`                      |          |
+| `units`       | number      | Number of application units to deploy                              | `1`                         |          |
 
 ### Outputs
 
-After applying, the module exports the following outputs:
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `application` | The deployed `juju_application` resource |
+| `provides`    | Map of provides endpoint names           |
+| `requires`    | Map of requires endpoint names           |
 
-| Name       | Description                 |
-|:-----------|:----------------------------|
-| `app_name` | Application name            |
-| `provides` | Map of `provides` endpoints |
-| `requires` | Map of `requires` endpoints |
+The `provides` output exposes the following endpoint names:
+
+| Key                 | Endpoint name       |
+|---------------------|---------------------|
+| `certificates`      | `certificates`      |
+| `trust_certificate` | `trust_certificate` |
+
+The `requires` output exposes the following endpoint names:
+
+| Key       | Endpoint name |
+|-----------|---------------|
+| `tracing` | `tracing`     |
 
 ## Usage
 
-Users should ensure that Terraform is aware of the Juju model dependency of the
-charm module.
+Ensure that Terraform is aware of the Juju model dependency of the charm module.
 
-To deploy this module with its required dependency, you can run
-the following command:
+```hcl
+module "manual-tls-certificates" {
+  source     = "git::https://github.com/canonical/manual-tls-certificates-operator//terraform"
+  model_uuid = juju_model.my_model.uuid
+}
+```
+
+To deploy this module with its required dependency, you can run the following
+command:
 
 ```shell
 terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```
-

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,14 +1,13 @@
 # Copyright 2024-2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
-output "app_name" {
-  description = "Application name"
-  value       = juju_application.manual_tls_certificates.name
+output "application" {
+  description = "The deployed `juju_application` resource"
+  value       = juju_application.manual_tls_certificates
 }
 
 output "provides" {
-  description = "Map of provides endpoints"
+  description = "Map of provides endpoint names"
   value = {
     certificates      = "certificates"
     trust_certificate = "trust_certificate"
@@ -16,7 +15,7 @@ output "provides" {
 }
 
 output "requires" {
-  description = "Map of requires endpoints"
+  description = "Map of requires endpoint names"
   value = {
     tracing = "tracing"
   }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,4 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+provider "juju" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,13 +2,12 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = "~> 1.0"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 1.0.0"
+      version = "~> 1.0"
     }
   }
 }
-

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,11 +1,6 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-variable "model_uuid" {
-  description = "UUID of the Juju model to deploy to"
-  type        = string
-}
-
 variable "app_name" {
   description = "Name of the application"
   type        = string
@@ -13,38 +8,42 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "The charm base"
+  description = "Operating system (for example, ubuntu@22.04)"
   type        = string
   default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to use for the charm"
+  description = "Charm channel to deploy from"
   type        = string
   default     = "1/stable"
 }
 
 variable "config" {
-  description = "The charm config"
+  description = "Map of charm configuration options"
   type        = map(string)
   default     = {}
 }
 
 variable "constraints" {
-  description = "The constraints to be applied"
+  description = "Constraints string"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy the charm into"
+  type        = string
 }
 
 variable "revision" {
-  description = "Revision of the charm to deploy"
+  description = "Charm revision to deploy. Null deploys the latest on given channel"
   type        = number
   default     = null
 }
 
 variable "units" {
-  description = "Number of units to deploy"
+  description = "Number of application units to deploy"
   type        = number
   default     = 1
 }
-


### PR DESCRIPTION
# Description

This PR updates the charm Terraform module for manual-tls-certificates-operator to be compliant with the [CC008 specification](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?usp=sharing). The most notable change here is that the `juju_application` resource for `manual-tls-certificates` is now provided as an output rather than just the created application's name.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
