### PR TITLE
feat(terraform): add juju_offer resources for certificates and trust_certificate endpoints

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,6 +37,7 @@ After applying, the module exports the following outputs:
 | `app_name` | Application name            |
 | `provides` | Map of `provides` endpoints |
 | `requires` | Map of `requires` endpoints |
+| `offers`   | Map of Juju offer URLs      |
 
 ## Usage
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,3 +23,17 @@ resource "juju_application" "manual_tls_certificates" {
   }
 }
 
+resource "juju_offer" "certificates" {
+  name             = "certificates"
+  model_uuid       = var.model_uuid
+  application_name = var.app_name
+  endpoints        = ["certificates"]
+}
+
+resource "juju_offer" "trust_certificate" {
+  name             = "trust-certificate"
+  model_uuid       = var.model_uuid
+  application_name = var.app_name
+  endpoints        = ["trust_certificate"]
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -21,3 +21,11 @@ output "requires" {
     tracing = "tracing"
   }
 }
+
+output "offers" {
+  description = "Map of Juju offer URLs"
+  value = {
+    certificates      = juju_offer.certificates.url
+    trust_certificate = juju_offer.trust_certificate.url
+  }
+}


### PR DESCRIPTION
# Description
Adds `juju_offer` resources for the `certificates` and `trust_certificate` endpoints of the
`manual-tls-certificates` charm, enabling cross-model integrations via Juju offers.
Follows the same pattern used in the
[self-signed-certificates-operator](https://github.com/canonical/self-signed-certificates-operator/blob/main/terraform/main.tf).
Closes #560
## Changes
- `terraform/main.tf`: added `juju_offer.certificates` and `juju_offer.trust_certificate` resources
- `terraform/outputs.tf`: added `offers` output exposing both offer URLs
- `terraform/README.md`: documented the new `offers` output in the Outputs table
# Checklist:
- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
